### PR TITLE
Add support for duration primitive

### DIFF
--- a/src/Generator.TemplateProject/Custom/DurationConverter.cs
+++ b/src/Generator.TemplateProject/Custom/DurationConverter.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Generator.CustomModels;
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Xml;
+
+/// <summary>
+/// Converts an ISO 8601 duration into a TimeSpan.
+/// </summary>
+public class DurationConverter : JsonConverter<TimeSpan>
+{
+    /// <inheritdoc/>
+    public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+#pragma warning disable CS8604 // Possible null reference argument. Read() is not called if the value is null. Verified in unit test.
+        return XmlConvert.ToTimeSpan(reader.GetString());
+#pragma warning restore CS8604 // Possible null reference argument.
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(XmlConvert.ToString(value));
+    }
+}

--- a/src/Generator.TemplateProject/Custom/MapDurationConverter.cs
+++ b/src/Generator.TemplateProject/Custom/MapDurationConverter.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Generator.CustomModels;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Xml;
+
+/// <summary>
+/// Converts a map of ISO 8601 durations into an IDictionary&lt;string, TimeSpan&lt;.
+/// </summary>
+public class MapDurationConverter : JsonConverter<IDictionary<string, TimeSpan>>
+{
+    /// <inheritdoc/>
+    public override IDictionary<string, TimeSpan> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("First token was not the start of a JSON object.");
+        }
+
+        var dictionary = new Dictionary<string, TimeSpan>();
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return dictionary;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException();
+            }
+
+            var key = reader.GetString();
+
+            reader.Read();
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                continue;
+            }
+
+#pragma warning disable CS8604 // Possible null reference argument.
+            // reader.GetString() won't return null, already checked above.
+            var value = XmlConvert.ToTimeSpan(reader.GetString());
+
+            // key cannot be null.
+            dictionary.Add(key, value);
+#pragma warning restore CS8604 // Possible null reference argument.
+        }
+
+        throw new JsonException("Final token was not the end of a JSON object.");
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, IDictionary<string, TimeSpan> dictionary, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        foreach ((string key, TimeSpan value) in dictionary)
+        {
+            writer.WritePropertyName(options.PropertyNamingPolicy?.ConvertName(key) ?? key);
+            writer.WriteStringValue(XmlConvert.ToString(value));
+        }
+
+        writer.WriteEndObject();
+    }
+}

--- a/src/Generator/Base/ClassEntity.cs
+++ b/src/Generator/Base/ClassEntity.cs
@@ -56,6 +56,11 @@ internal abstract class ClassEntity : Entity
             return new ObjectProperty(entity, objectInfo, Name, Options);
         }
 
+        if (schema is DTDurationInfo)
+        {
+            return new DurationProperty(entity, Options);
+        }
+
         return new PrimitiveProperty(entity, schema, Name, Options);
     }
 

--- a/src/Generator/Generator.csproj
+++ b/src/Generator/Generator.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
     <Content Include="..\Generator.TemplateProject\Generator.TemplateProject.csproj">
       <Pack>true</Pack>
@@ -52,7 +52,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.DigitalTwins.Core" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="3.12.7" />
-    <PackageReference Include="MinVer" PrivateAssets="all" Version="3.1.0"/>
+    <PackageReference Include="MinVer" PrivateAssets="all" Version="3.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/src/Generator/ModelGenerator.cs
+++ b/src/Generator/ModelGenerator.cs
@@ -10,6 +10,7 @@ public class ModelGenerator
 {
     private readonly IEnumerable<string> customClasses = new List<string>
     {
+        "DurationConverter.cs",
         "Extensions.cs",
         "ModelHelper.cs",
         "Relationship.cs",

--- a/src/Generator/ModelGenerator.cs
+++ b/src/Generator/ModelGenerator.cs
@@ -12,6 +12,7 @@ public class ModelGenerator
     {
         "DurationConverter.cs",
         "Extensions.cs",
+        "MapDurationConverter.cs",
         "ModelHelper.cs",
         "Relationship.cs",
         "RelationshipCollection.cs",

--- a/src/Generator/Property/DurationProperty.cs
+++ b/src/Generator/Property/DurationProperty.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DigitalWorkplace.DigitalTwins.Models.Generator;
+
+internal class DurationProperty : Property
+{
+    internal DurationProperty(DTNamedEntityInfo entity, ModelGeneratorOptions options) : base(options)
+    {
+        Name = entity.Name;
+        JsonName = entity.Name;
+        Obsolete = entity.IsObsolete();
+        Type = "TimeSpan?";
+    }
+
+    internal override void WriteTo(StreamWriter streamWriter)
+    {
+        streamWriter.WriteLine($"{indent}{indent}[JsonConverter(typeof(DurationConverter))]");
+        base.WriteTo(streamWriter);
+    }
+}

--- a/src/Generator/Property/MapProperty.cs
+++ b/src/Generator/Property/MapProperty.cs
@@ -5,12 +5,13 @@ namespace Microsoft.DigitalWorkplace.DigitalTwins.Models.Generator;
 
 internal class MapProperty : Property
 {
+    private readonly string? mapValue;
+
     internal MapProperty(DTNamedEntityInfo entity, DTMapInfo map, string enclosingClass, ModelGeneratorOptions options) : base(options)
     {
         Name = entity.Name;
         JsonName = entity.Name;
         Types.TryGetNonNullable(map.MapKey.Schema.EntityKind, out var mapKey);
-        string? mapValue;
         if (map.MapValue.Schema is DTEnumInfo enumInfo)
         {
             var enumEntity = new EnumPropEntity(enumInfo, enclosingClass, options);
@@ -30,5 +31,15 @@ internal class MapProperty : Property
 
         Type = $"IDictionary<{mapKey?.TrimEnd('?')}, {mapValue?.TrimEnd('?')}>?";
         Obsolete = entity.IsObsolete();
+    }
+
+    internal override void WriteTo(StreamWriter streamWriter)
+    {
+        if (mapValue == nameof(TimeSpan))
+        {
+            streamWriter.WriteLine($"{indent}{indent}[JsonConverter(typeof(MapDurationConverter))]");
+        }
+
+        base.WriteTo(streamWriter);
     }
 }

--- a/src/Generator/Types.cs
+++ b/src/Generator/Types.cs
@@ -24,7 +24,8 @@ internal static class Types
             { DTEntityKind.Time, "object" },
             { DTEntityKind.Float, "float" },
             { DTEntityKind.Double, "double" },
-            { DTEntityKind.String, "string" }
+            { DTEntityKind.String, "string" },
+            { DTEntityKind.Duration, "TimeSpan" }
         };
 
     internal static bool TryGetNullable(DTEntityKind entityKind, out string? type)

--- a/test/Generator.Tests.Generated/Asset.cs
+++ b/test/Generator.Tests.Generated/Asset.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Generator.Tests.Generated
+{
+    using Azure;
+    using Azure.DigitalTwins.Core;
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
+
+    public class Asset : BasicDigitalTwin, IEquatable<Asset>, IEquatable<BasicDigitalTwin>
+    {
+        public Asset()
+        {
+            Metadata.ModelId = ModelId;
+        }
+        [JsonIgnore]
+        public static string ModelId { get; } = "dtmi:test:Asset;1";
+        [JsonPropertyName("assetTag")]
+        public string? AssetTag { get; set; }
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+        [JsonPropertyName("serialNumber")]
+        public string? SerialNumber { get; set; }
+        [JsonConverter(typeof(DurationConverter))]
+        [JsonPropertyName("maintenanceInterval")]
+        public TimeSpan? MaintenanceInterval { get; set; }
+        [JsonIgnore]
+        public AssetIsLocatedInRelationshipCollection IsLocatedIn { get; set; } = new AssetIsLocatedInRelationshipCollection();
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as Asset);
+        }
+
+        public bool Equals(Asset? other)
+        {
+            return other is not null && Id == other.Id && Metadata.ModelId == other.Metadata.ModelId && AssetTag == other.AssetTag && Name == other.Name && SerialNumber == other.SerialNumber && MaintenanceInterval == other.MaintenanceInterval;
+        }
+
+        public static bool operator ==(Asset? left, Asset? right)
+        {
+            return EqualityComparer<Asset?>.Default.Equals(left, right);
+        }
+
+        public static bool operator !=(Asset? left, Asset? right)
+        {
+            return !(left == right);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.CustomHash(Id?.GetHashCode(), Metadata?.ModelId?.GetHashCode(), AssetTag?.GetHashCode(), Name?.GetHashCode(), SerialNumber?.GetHashCode(), MaintenanceInterval?.GetHashCode());
+        }
+
+        public bool Equals(BasicDigitalTwin? other)
+        {
+            return Equals(other as Asset) || new TwinEqualityComparer().Equals(this, other);
+        }
+    }
+}

--- a/test/Generator.Tests.Generated/Asset.cs
+++ b/test/Generator.Tests.Generated/Asset.cs
@@ -27,6 +27,9 @@ namespace Generator.Tests.Generated
         [JsonConverter(typeof(DurationConverter))]
         [JsonPropertyName("maintenanceInterval")]
         public TimeSpan? MaintenanceInterval { get; set; }
+        [JsonConverter(typeof(MapDurationConverter))]
+        [JsonPropertyName("runtimeDurations")]
+        public IDictionary<string, TimeSpan>? RuntimeDurations { get; set; }
         [JsonIgnore]
         public AssetIsLocatedInRelationshipCollection IsLocatedIn { get; set; } = new AssetIsLocatedInRelationshipCollection();
         public override bool Equals(object? obj)
@@ -36,7 +39,7 @@ namespace Generator.Tests.Generated
 
         public bool Equals(Asset? other)
         {
-            return other is not null && Id == other.Id && Metadata.ModelId == other.Metadata.ModelId && AssetTag == other.AssetTag && Name == other.Name && SerialNumber == other.SerialNumber && MaintenanceInterval == other.MaintenanceInterval;
+            return other is not null && Id == other.Id && Metadata.ModelId == other.Metadata.ModelId && AssetTag == other.AssetTag && Name == other.Name && SerialNumber == other.SerialNumber && MaintenanceInterval == other.MaintenanceInterval && RuntimeDurations == other.RuntimeDurations;
         }
 
         public static bool operator ==(Asset? left, Asset? right)
@@ -51,7 +54,7 @@ namespace Generator.Tests.Generated
 
         public override int GetHashCode()
         {
-            return this.CustomHash(Id?.GetHashCode(), Metadata?.ModelId?.GetHashCode(), AssetTag?.GetHashCode(), Name?.GetHashCode(), SerialNumber?.GetHashCode(), MaintenanceInterval?.GetHashCode());
+            return this.CustomHash(Id?.GetHashCode(), Metadata?.ModelId?.GetHashCode(), AssetTag?.GetHashCode(), Name?.GetHashCode(), SerialNumber?.GetHashCode(), MaintenanceInterval?.GetHashCode(), RuntimeDurations?.GetHashCode());
         }
 
         public bool Equals(BasicDigitalTwin? other)

--- a/test/Generator.Tests.Generated/DurationConverter.cs
+++ b/test/Generator.Tests.Generated/DurationConverter.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Generator.Tests.Generated;
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Xml;
+
+/// <summary>
+/// Converts an ISO 8601 duration into a TimeSpan.
+/// </summary>
+public class DurationConverter : JsonConverter<TimeSpan>
+{
+    /// <inheritdoc/>
+    public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+#pragma warning disable CS8604 // Possible null reference argument. Read() is not called if the value is null. Verified in unit test.
+        return XmlConvert.ToTimeSpan(reader.GetString());
+#pragma warning restore CS8604 // Possible null reference argument.
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(XmlConvert.ToString(value));
+    }
+}

--- a/test/Generator.Tests.Generated/MapDurationConverter.cs
+++ b/test/Generator.Tests.Generated/MapDurationConverter.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Generator.Tests.Generated;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Xml;
+
+/// <summary>
+/// Converts a map of ISO 8601 durations into an IDictionary&lt;string, TimeSpan&lt;.
+/// </summary>
+public class MapDurationConverter : JsonConverter<IDictionary<string, TimeSpan>>
+{
+    /// <inheritdoc/>
+    public override IDictionary<string, TimeSpan> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("First token was not the start of a JSON object.");
+        }
+
+        var dictionary = new Dictionary<string, TimeSpan>();
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return dictionary;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException();
+            }
+
+            var key = reader.GetString();
+
+            reader.Read();
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                continue;
+            }
+
+#pragma warning disable CS8604 // Possible null reference argument.
+            // reader.GetString() won't return null, already checked above.
+            var value = XmlConvert.ToTimeSpan(reader.GetString());
+
+            // key cannot be null.
+            dictionary.Add(key, value);
+#pragma warning restore CS8604 // Possible null reference argument.
+        }
+
+        throw new JsonException("Final token was not the end of a JSON object.");
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, IDictionary<string, TimeSpan> dictionary, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        foreach ((string key, TimeSpan value) in dictionary)
+        {
+            writer.WritePropertyName(options.PropertyNamingPolicy?.ConvertName(key) ?? key);
+            writer.WriteStringValue(XmlConvert.ToString(value));
+        }
+
+        writer.WriteEndObject();
+    }
+}

--- a/test/Generator.Tests.Generated/Relationship/Asset/AssetIsLocatedInRelationship.cs
+++ b/test/Generator.Tests.Generated/Relationship/Asset/AssetIsLocatedInRelationship.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Generator.Tests.Generated
+{
+    using Azure;
+    using Azure.DigitalTwins.Core;
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
+
+    public class AssetIsLocatedInRelationship : Relationship<Space>, IEquatable<AssetIsLocatedInRelationship>
+    {
+        public AssetIsLocatedInRelationship()
+        {
+            Name = "isLocatedIn";
+        }
+
+        public AssetIsLocatedInRelationship(Asset source, Space target) : this()
+        {
+            InitializeFromTwins(source, target);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as AssetIsLocatedInRelationship);
+        }
+
+        public bool Equals(AssetIsLocatedInRelationship? other)
+        {
+            return other is not null && Id == other.Id && SourceId == other.SourceId && TargetId == other.TargetId && Target == other.Target && Name == other.Name;
+        }
+
+        public static bool operator ==(AssetIsLocatedInRelationship? left, AssetIsLocatedInRelationship? right)
+        {
+            return EqualityComparer<AssetIsLocatedInRelationship?>.Default.Equals(left, right);
+        }
+
+        public static bool operator !=(AssetIsLocatedInRelationship? left, AssetIsLocatedInRelationship? right)
+        {
+            return !(left == right);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.CustomHash(Id?.GetHashCode(), SourceId?.GetHashCode(), TargetId?.GetHashCode(), Target?.GetHashCode());
+        }
+
+        public override bool Equals(BasicRelationship? other)
+        {
+            return Equals(other as AssetIsLocatedInRelationship) || new RelationshipEqualityComparer().Equals(this, other);
+        }
+    }
+}

--- a/test/Generator.Tests.Generated/Relationship/Asset/AssetIsLocatedInRelationshipCollection.cs
+++ b/test/Generator.Tests.Generated/Relationship/Asset/AssetIsLocatedInRelationshipCollection.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Generator.Tests.Generated
+{
+    using Azure;
+    using Azure.DigitalTwins.Core;
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
+    using System.Linq;
+
+    public class AssetIsLocatedInRelationshipCollection : RelationshipCollection<AssetIsLocatedInRelationship, Space>
+    {
+        public AssetIsLocatedInRelationshipCollection(IEnumerable<AssetIsLocatedInRelationship>? relationships = default) : base(relationships ?? Enumerable.Empty<AssetIsLocatedInRelationship>())
+        {
+        }
+    }
+}

--- a/test/Generator.Tests/AssertHelper.cs
+++ b/test/Generator.Tests/AssertHelper.cs
@@ -18,6 +18,6 @@ internal static class AssertHelper
         }
 
         // Includes custom files
-        Assert.AreEqual(41, outFileNames.Count, "Expected 41 files to be generated");
+        Assert.AreEqual(45, outFileNames.Count, "Expected 45 files to be generated");
     }
 }

--- a/test/Generator.Tests/AssertHelper.cs
+++ b/test/Generator.Tests/AssertHelper.cs
@@ -18,6 +18,13 @@ internal static class AssertHelper
         }
 
         // Includes custom files
-        Assert.AreEqual(45, outFileNames.Count, "Expected 45 files to be generated");
+        Assert.AreEqual(46, outFileNames.Count, "Expected 46 files to be generated");
+    }
+
+    internal static void AssertJsonEquivalent(string expected, string actual)
+    {
+        using var expectedToken = JsonDocument.Parse(expected);
+        using var actualToken = JsonDocument.Parse(actual);
+        expectedToken.DeepEquals(actualToken);
     }
 }

--- a/test/Generator.Tests/DurationConverter.UnitTests.cs
+++ b/test/Generator.Tests/DurationConverter.UnitTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Generator.Tests;
+
+[TestClass]
+public class DurationConverterUnitTests
+{
+    private readonly JsonSerializerOptions options = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+
+    [TestMethod]
+    public void PopulatedDurationPropertyDeserializesCorrectly()
+    {
+        var json = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"maintenanceInterval\":\"P90DT8H7M6S\",\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
+        var expectedAsset = new Asset { Id = "d8985302-4ee1-4a10-b2f5-e854e1682422", AssetTag = "ABC123", Name = "Test Asset", SerialNumber = "SN12345", MaintenanceInterval = new TimeSpan(90, 8, 7, 6) };
+        var deserializedAsset = JsonSerializer.Deserialize<Asset>(json, options);
+        Assert.AreEqual(expectedAsset.Id, deserializedAsset?.Id);
+        Assert.AreEqual(expectedAsset.Name, deserializedAsset?.Name);
+        Assert.AreEqual(expectedAsset.SerialNumber, deserializedAsset?.SerialNumber);
+        Assert.AreEqual(expectedAsset.MaintenanceInterval, deserializedAsset?.MaintenanceInterval);
+        Assert.AreEqual(expectedAsset.Metadata.ModelId, deserializedAsset?.Metadata.ModelId);
+    }
+
+    [TestMethod]
+    public void NullDurationPropertyDeserializesCorrectly()
+    {
+        var json = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"maintenanceInterval\":null,\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
+        var expectedAsset = new Asset { Id = "d8985302-4ee1-4a10-b2f5-e854e1682422", AssetTag = "ABC123", Name = "Test Asset", SerialNumber = "SN12345", MaintenanceInterval = null };
+        var deserializedAsset = JsonSerializer.Deserialize<Asset>(json, options);
+        Assert.AreEqual(expectedAsset.Id, deserializedAsset?.Id);
+        Assert.AreEqual(expectedAsset.Name, deserializedAsset?.Name);
+        Assert.AreEqual(expectedAsset.SerialNumber, deserializedAsset?.SerialNumber);
+        Assert.AreEqual(expectedAsset.MaintenanceInterval, deserializedAsset?.MaintenanceInterval);
+        Assert.AreEqual(expectedAsset.Metadata.ModelId, deserializedAsset?.Metadata.ModelId);
+    }
+
+    [TestMethod]
+    public void PopulatedDurationPropertySerializesCorrectly()
+    {
+        var expectedJson = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"maintenanceInterval\":\"P90DT8H7M6S\",\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
+        var asset = new Asset { Id = "d8985302-4ee1-4a10-b2f5-e854e1682422", AssetTag = "ABC123", Name = "Test Asset", SerialNumber = "SN12345", MaintenanceInterval = new TimeSpan(90, 8, 7, 6) };
+        var actualJson = JsonSerializer.Serialize(asset, options);
+        AssertHelper.AssertJsonEquivalent(expectedJson, actualJson);
+    }
+
+    [TestMethod]
+    public void NullDurationPropertySerializesCorrectly()
+    {
+        var expectedJson = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"squareMeter\":2,\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"maintenanceInterval\":null,\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
+        var asset = new Asset { Id = "d8985302-4ee1-4a10-b2f5-e854e1682422", AssetTag = "ABC123", Name = "Test Asset", SerialNumber = "SN12345", MaintenanceInterval = null };
+        var actualJson = JsonSerializer.Serialize<Asset>(asset, options);
+        AssertHelper.AssertJsonEquivalent(expectedJson, actualJson);
+    }
+}

--- a/test/Generator.Tests/MapDurationConverter.UnitTests.cs
+++ b/test/Generator.Tests/MapDurationConverter.UnitTests.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Generator.Tests;
+
+[TestClass]
+public class MapDurationConverterUnitTests
+{
+    private readonly JsonSerializerOptions options = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+
+    [TestMethod]
+    public void PopulatedMapDurationPropertyDeserializesCorrectly()
+    {
+        var json = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"runtimeDurations\":{{\"Monday\":\"PT1H\",\"Wednesday\":\"PT2H30M\"}},\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
+        var expectedAsset = new Asset
+        {
+            Id = "d8985302-4ee1-4a10-b2f5-e854e1682422",
+            AssetTag = "ABC123",
+            Name = "Test Asset",
+            SerialNumber = "SN12345",
+            RuntimeDurations = new Dictionary<string, TimeSpan>()
+            {
+                ["Monday"] = new TimeSpan(1, 0, 0),
+                ["Wednesday"] = new TimeSpan(2, 30, 0)
+            }
+        };
+        var deserializedAsset = JsonSerializer.Deserialize<Asset>(json, options);
+        Assert.AreEqual(expectedAsset.Id, deserializedAsset?.Id);
+        Assert.AreEqual(expectedAsset.Name, deserializedAsset?.Name);
+        Assert.AreEqual(expectedAsset.SerialNumber, deserializedAsset?.SerialNumber);
+        Assert.AreEqual(expectedAsset.RuntimeDurations["Monday"], expectedAsset.RuntimeDurations["Monday"]);
+        Assert.AreEqual(expectedAsset.RuntimeDurations["Wednesday"], expectedAsset.RuntimeDurations["Wednesday"]);
+        Assert.AreEqual(expectedAsset.Metadata.ModelId, deserializedAsset?.Metadata.ModelId);
+    }
+
+    [TestMethod]
+    public void NullMapDurationPropertyDeserializesCorrectly()
+    {
+        var json = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"runtimeDurations\":null,\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
+        var expectedAsset = new Asset
+        {
+            Id = "d8985302-4ee1-4a10-b2f5-e854e1682422",
+            AssetTag = "ABC123",
+            Name = "Test Asset",
+            SerialNumber = "SN12345",
+            RuntimeDurations = null
+        };
+        var deserializedAsset = JsonSerializer.Deserialize<Asset>(json, options);
+        Assert.AreEqual(expectedAsset.Id, deserializedAsset?.Id);
+        Assert.AreEqual(expectedAsset.Name, deserializedAsset?.Name);
+        Assert.AreEqual(expectedAsset.SerialNumber, deserializedAsset?.SerialNumber);
+        Assert.AreEqual(expectedAsset.RuntimeDurations, expectedAsset.RuntimeDurations);
+        Assert.AreEqual(expectedAsset.Metadata.ModelId, deserializedAsset?.Metadata.ModelId);
+    }
+
+    [TestMethod]
+    public void PopulatedMapDurationPropertySerializesCorrectly()
+    {
+        var asset = new Asset
+        {
+            Id = "d8985302-4ee1-4a10-b2f5-e854e1682422",
+            AssetTag = "ABC123",
+            Name = "Test Asset",
+            SerialNumber = "SN12345",
+            RuntimeDurations = new Dictionary<string, TimeSpan>()
+            {
+                ["Monday"] = new TimeSpan(1, 0, 0),
+                ["Wednesday"] = new TimeSpan(2, 30, 0)
+            }
+        };
+        var expectedJson = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"runtimeDurations\":{{\"Monday\":\"PT1H\",\"Wednesday\":\"PT2H30M\"}},\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
+        var actualJson = JsonSerializer.Serialize<Asset>(asset, options);
+        AssertHelper.AssertJsonEquivalent(expectedJson, actualJson);
+    }
+
+    [TestMethod]
+    public void NullMapDurationPropertySerializesCorrectly()
+    {
+        var asset = new Asset
+        {
+            Id = "d8985302-4ee1-4a10-b2f5-e854e1682422",
+            AssetTag = "ABC123",
+            Name = "Test Asset",
+            SerialNumber = "SN12345",
+            RuntimeDurations = null
+        };
+        var expectedJson = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"runtimeDurations\":null,\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
+        var actualJson = JsonSerializer.Serialize<Asset>(asset, options);
+        AssertHelper.AssertJsonEquivalent(expectedJson, actualJson);
+    }
+}

--- a/test/Generator.Tests/Models.UnitTests.cs
+++ b/test/Generator.Tests/Models.UnitTests.cs
@@ -153,7 +153,7 @@ public class ModelsUnitTests
     [TestMethod]
     public void ModelSubclassDeserializesCorrectly()
     {
-        var json = $"{{\"$dtId\":\"d6eee516-8e60-4845-993d-0e35c5af677e\",\"number\":0,\"name\":\"TestBuilding\",\"squareFootArea\":0,\"status\":\"Active\",\"$metadata\":{{\"$model\":\"{Building.ModelId}\"}}}}";
+        var json = $"{{\"$dtId\":\"d6eee516-8e60-4845-993d-0e35c5af677e\",\"number\":0,\"squareMeter\":2,\"name\":\"TestBuilding\",\"squareFootArea\":0,\"status\":\"Active\",\"$metadata\":{{\"$model\":\"{Building.ModelId}\"}}}}";
         var expectedBuilding = new Building { Id = "d6eee516-8e60-4845-993d-0e35c5af677e", Name = "TestBuilding", Status = SpaceStatus.Active, Number = 2 };
         var deserializedBuilding = JsonSerializer.Deserialize<Building>(json, options);
         Assert.AreEqual(expectedBuilding.Id, deserializedBuilding?.Id);

--- a/test/Generator.Tests/Models.UnitTests.cs
+++ b/test/Generator.Tests/Models.UnitTests.cs
@@ -163,6 +163,50 @@ public class ModelsUnitTests
     }
 
     [TestMethod]
+    public void ModelWithPopulatedDurationPropertyDeserializesCorrectly()
+    {
+        var json = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"squareMeter\":2,\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"maintenanceInterval\":\"P90DT8H7M6S\",\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
+        var expectedAsset = new Asset { Id = "d8985302-4ee1-4a10-b2f5-e854e1682422", AssetTag = "ABC123", Name = "Test Asset", SerialNumber = "SN12345", MaintenanceInterval = new TimeSpan(90, 8, 7, 6) };
+        var deserializedAsset = JsonSerializer.Deserialize<Asset>(json, options);
+        Assert.AreEqual(expectedAsset.Id, deserializedAsset?.Id);
+        Assert.AreEqual(expectedAsset.Name, deserializedAsset?.Name);
+        Assert.AreEqual(expectedAsset.SerialNumber, deserializedAsset?.SerialNumber);
+        Assert.AreEqual(expectedAsset.MaintenanceInterval, deserializedAsset?.MaintenanceInterval);
+        Assert.AreEqual(expectedAsset.Metadata.ModelId, deserializedAsset?.Metadata.ModelId);
+    }
+
+    [TestMethod]
+    public void ModelWithNullDurationPropertyDeserializesCorrectly()
+    {
+        var json = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"squareMeter\":2,\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"maintenanceInterval\":null,\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
+        var expectedAsset = new Asset { Id = "d8985302-4ee1-4a10-b2f5-e854e1682422", AssetTag = "ABC123", Name = "Test Asset", SerialNumber = "SN12345", MaintenanceInterval = null };
+        var deserializedAsset = JsonSerializer.Deserialize<Asset>(json, options);
+        Assert.AreEqual(expectedAsset.Id, deserializedAsset?.Id);
+        Assert.AreEqual(expectedAsset.Name, deserializedAsset?.Name);
+        Assert.AreEqual(expectedAsset.SerialNumber, deserializedAsset?.SerialNumber);
+        Assert.AreEqual(expectedAsset.MaintenanceInterval, deserializedAsset?.MaintenanceInterval);
+        Assert.AreEqual(expectedAsset.Metadata.ModelId, deserializedAsset?.Metadata.ModelId);
+    }
+
+    [TestMethod]
+    public void ModelWithPopulatedDurationPropertySerializesCorrectly()
+    {
+        var expectedJson = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"squareMeter\":2,\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"maintenanceInterval\":\"P90DT8H7M6S\",\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
+        var asset = new Asset { Id = "d8985302-4ee1-4a10-b2f5-e854e1682422", AssetTag = "ABC123", Name = "Test Asset", SerialNumber = "SN12345", MaintenanceInterval = new TimeSpan(90, 8, 7, 6) };
+        var actualJson = JsonSerializer.Serialize(asset, options);
+        AssertJsonEquivalent(expectedJson, actualJson);
+    }
+
+    [TestMethod]
+    public void ModelWithNullDurationPropertySerializesCorrectly()
+    {
+        var expectedJson = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"squareMeter\":2,\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"maintenanceInterval\":null,\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
+        var asset = new Asset { Id = "d8985302-4ee1-4a10-b2f5-e854e1682422", AssetTag = "ABC123", Name = "Test Asset", SerialNumber = "SN12345", MaintenanceInterval = null };
+        var actualJson = JsonSerializer.Serialize<Asset>(asset, options);
+        AssertJsonEquivalent(expectedJson, actualJson);
+    }
+
+    [TestMethod]
     public void RelationshipSerializesCorrectly()
     {
         var sourceId = Guid.NewGuid();

--- a/test/Generator.Tests/Models.UnitTests.cs
+++ b/test/Generator.Tests/Models.UnitTests.cs
@@ -132,10 +132,10 @@ public class ModelsUnitTests
         var expectedJsonWithNulls = $"{{\"$metadata\":{{\"$model\":\"{Building.ModelId}\"}},\"businessEntityNumber\":null,\"number\":null,\"shortName\":null,\"squareMeter\":null,\"rationalSortKey\":null,\"regionId\":null,\"startOfBusinessTime\":null,\"endOfBusinessTime\":null,\"businessEntityName\":null,\"amenities\":null,\"externalId\":null,\"name\":\"TestBuilding\",\"roomKey\":null,\"friendlyName\":null,\"description\":null,\"squareFootArea\":null,\"capabilities\":null,\"status\":null,\"physicalSpace\":null,\"$dtId\":\"{guid}\",\"$etag\":null}}";
         var expectedJsonWithoutNulls = $"{{\"$metadata\":{{\"$model\":\"{Building.ModelId}\"}},\"name\":\"TestBuilding\",\"$dtId\":\"{guid}\"}}";
         var actualJsonWithNulls = JsonSerializer.Serialize(building);
-        AssertJsonEquivalent(expectedJsonWithNulls, actualJsonWithNulls);
+        AssertHelper.AssertJsonEquivalent(expectedJsonWithNulls, actualJsonWithNulls);
 
         var actualJsonWithoutNulls = JsonSerializer.Serialize(building, options);
-        AssertJsonEquivalent(expectedJsonWithoutNulls, actualJsonWithoutNulls);
+        AssertHelper.AssertJsonEquivalent(expectedJsonWithoutNulls, actualJsonWithoutNulls);
     }
 
     [TestMethod]
@@ -153,57 +153,13 @@ public class ModelsUnitTests
     [TestMethod]
     public void ModelSubclassDeserializesCorrectly()
     {
-        var json = $"{{\"$dtId\":\"d6eee516-8e60-4845-993d-0e35c5af677e\",\"number\":0,\"squareMeter\":2,\"name\":\"TestBuilding\",\"squareFootArea\":0,\"status\":\"Active\",\"$metadata\":{{\"$model\":\"{Building.ModelId}\"}}}}";
+        var json = $"{{\"$dtId\":\"d6eee516-8e60-4845-993d-0e35c5af677e\",\"number\":0,\"name\":\"TestBuilding\",\"squareFootArea\":0,\"status\":\"Active\",\"$metadata\":{{\"$model\":\"{Building.ModelId}\"}}}}";
         var expectedBuilding = new Building { Id = "d6eee516-8e60-4845-993d-0e35c5af677e", Name = "TestBuilding", Status = SpaceStatus.Active, Number = 2 };
         var deserializedBuilding = JsonSerializer.Deserialize<Building>(json, options);
         Assert.AreEqual(expectedBuilding.Id, deserializedBuilding?.Id);
         Assert.AreEqual(expectedBuilding.Name, deserializedBuilding?.Name);
         Assert.AreEqual(expectedBuilding.Status, deserializedBuilding?.Status);
         Assert.AreEqual(expectedBuilding.Metadata.ModelId, deserializedBuilding?.Metadata.ModelId);
-    }
-
-    [TestMethod]
-    public void ModelWithPopulatedDurationPropertyDeserializesCorrectly()
-    {
-        var json = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"squareMeter\":2,\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"maintenanceInterval\":\"P90DT8H7M6S\",\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
-        var expectedAsset = new Asset { Id = "d8985302-4ee1-4a10-b2f5-e854e1682422", AssetTag = "ABC123", Name = "Test Asset", SerialNumber = "SN12345", MaintenanceInterval = new TimeSpan(90, 8, 7, 6) };
-        var deserializedAsset = JsonSerializer.Deserialize<Asset>(json, options);
-        Assert.AreEqual(expectedAsset.Id, deserializedAsset?.Id);
-        Assert.AreEqual(expectedAsset.Name, deserializedAsset?.Name);
-        Assert.AreEqual(expectedAsset.SerialNumber, deserializedAsset?.SerialNumber);
-        Assert.AreEqual(expectedAsset.MaintenanceInterval, deserializedAsset?.MaintenanceInterval);
-        Assert.AreEqual(expectedAsset.Metadata.ModelId, deserializedAsset?.Metadata.ModelId);
-    }
-
-    [TestMethod]
-    public void ModelWithNullDurationPropertyDeserializesCorrectly()
-    {
-        var json = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"squareMeter\":2,\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"maintenanceInterval\":null,\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
-        var expectedAsset = new Asset { Id = "d8985302-4ee1-4a10-b2f5-e854e1682422", AssetTag = "ABC123", Name = "Test Asset", SerialNumber = "SN12345", MaintenanceInterval = null };
-        var deserializedAsset = JsonSerializer.Deserialize<Asset>(json, options);
-        Assert.AreEqual(expectedAsset.Id, deserializedAsset?.Id);
-        Assert.AreEqual(expectedAsset.Name, deserializedAsset?.Name);
-        Assert.AreEqual(expectedAsset.SerialNumber, deserializedAsset?.SerialNumber);
-        Assert.AreEqual(expectedAsset.MaintenanceInterval, deserializedAsset?.MaintenanceInterval);
-        Assert.AreEqual(expectedAsset.Metadata.ModelId, deserializedAsset?.Metadata.ModelId);
-    }
-
-    [TestMethod]
-    public void ModelWithPopulatedDurationPropertySerializesCorrectly()
-    {
-        var expectedJson = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"squareMeter\":2,\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"maintenanceInterval\":\"P90DT8H7M6S\",\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
-        var asset = new Asset { Id = "d8985302-4ee1-4a10-b2f5-e854e1682422", AssetTag = "ABC123", Name = "Test Asset", SerialNumber = "SN12345", MaintenanceInterval = new TimeSpan(90, 8, 7, 6) };
-        var actualJson = JsonSerializer.Serialize(asset, options);
-        AssertJsonEquivalent(expectedJson, actualJson);
-    }
-
-    [TestMethod]
-    public void ModelWithNullDurationPropertySerializesCorrectly()
-    {
-        var expectedJson = $"{{\"$dtId\":\"d8985302-4ee1-4a10-b2f5-e854e1682422\",\"assetTag\":\"12345\",\"squareMeter\":2,\"name\":\"Test Asset\",\"serialNumber\":\"SN12345\",\"maintenanceInterval\":null,\"$metadata\":{{\"$model\":\"{Asset.ModelId}\"}}}}";
-        var asset = new Asset { Id = "d8985302-4ee1-4a10-b2f5-e854e1682422", AssetTag = "ABC123", Name = "Test Asset", SerialNumber = "SN12345", MaintenanceInterval = null };
-        var actualJson = JsonSerializer.Serialize<Asset>(asset, options);
-        AssertJsonEquivalent(expectedJson, actualJson);
     }
 
     [TestMethod]
@@ -215,7 +171,7 @@ public class ModelsUnitTests
         var expectedJson = $"{{\"$relationshipName\":\"hasAddress\",\"$relationshipId\":\"{relationshipId}\",\"$sourceId\":\"{sourceId}\",\"$targetId\":\"{targetId}\"}}";
         var relationship = new BuildingHasAddressRelationship { Id = relationshipId.ToString(), SourceId = sourceId.ToString(), TargetId = targetId.ToString() };
         var actualJson = JsonSerializer.Serialize(relationship, options);
-        AssertJsonEquivalent(expectedJson, actualJson);
+        AssertHelper.AssertJsonEquivalent(expectedJson, actualJson);
     }
 
     [TestMethod]
@@ -238,12 +194,5 @@ public class ModelsUnitTests
         Assert.AreEqual(expectedRelationship.SourceId, deserializedBaseRelationship?.SourceId);
         Assert.AreEqual(expectedRelationship.TargetId, deserializedBaseRelationship?.TargetId);
         Assert.AreEqual(expectedRelationship.Name, deserializedBaseRelationship?.Name);
-    }
-
-    private void AssertJsonEquivalent(string expected, string actual)
-    {
-        using var expectedToken = JsonDocument.Parse(expected);
-        using var actualToken = JsonDocument.Parse(actual);
-        expectedToken.DeepEquals(actualToken);
     }
 }

--- a/test/Generator.Tests/TestDtdlModels/Asset.json
+++ b/test/Generator.Tests/TestDtdlModels/Asset.json
@@ -2,7 +2,7 @@
   "@id": "dtmi:test:Asset;1",
   "@type": "Interface",
   "@context": "dtmi:dtdl:context;2",
-  "displayName": "Address",
+  "displayName": "Asset",
   "contents": [
     {
       "@type": "Property",

--- a/test/Generator.Tests/TestDtdlModels/Asset.json
+++ b/test/Generator.Tests/TestDtdlModels/Asset.json
@@ -29,6 +29,22 @@
       "name": "maintenanceInterval"
     },
     {
+      "@type": "Property",
+      "name": "runtimeDurations",
+      "writable": true,
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "dayOfWeek",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "runtime",
+          "schema": "duration"
+        }
+      }
+    },
+    {
       "@type": "Relationship",
       "target": "dtmi:test:Space;1",
       "name": "isLocatedIn"

--- a/test/Generator.Tests/TestDtdlModels/Asset.json
+++ b/test/Generator.Tests/TestDtdlModels/Asset.json
@@ -1,0 +1,37 @@
+{
+  "@id": "dtmi:test:Asset;1",
+  "@type": "Interface",
+  "@context": "dtmi:dtdl:context;2",
+  "displayName": "Address",
+  "contents": [
+    {
+      "@type": "Property",
+      "schema": "string",
+      "writable": true,
+      "name": "assetTag"
+    },
+    {
+      "@type": "Property",
+      "schema": "string",
+      "writable": true,
+      "name": "name"
+    },
+    {
+      "@type": "Property",
+      "schema": "string",
+      "writable": true,
+      "name": "serialNumber"
+    },
+    {
+      "@type": "Property",
+      "schema": "duration",
+      "writable": true,
+      "name": "maintenanceInterval"
+    },
+    {
+      "@type": "Relationship",
+      "target": "dtmi:test:Space;1",
+      "name": "isLocatedIn"
+    }
+  ]
+}


### PR DESCRIPTION
Adds:
- `DurationConverter`: handles converting an ISO 8601-formatted duration into a .NET `TimeSpan?` object. Example: `P3Y6M4DT12H30M5S` (three years, six months, four days, twelve hours, thirty minutes, and five seconds)
- `MapDurationConverter`: handles converting a map of ISO 8601-formatted durations into a .NET `IDictionary<string, TimeSpan>` object.
- Unit tests for `DurationConverter` and `MapDurationConverter`.

Updates:
- `ModelGenerator`: copies `DurationConverter.cs` and `MapDurationConverter.cs` to destination. 
- Properties are now generated with `[JsonConverter(typeof(DurationConverter))]` or `[JsonConverter(typeof(MapDurationConverter))]` depending on DTDL model.

---

Closes #16.