### PR TITLE
Users/shdeb/fix release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,16 +14,16 @@ permissions:
 
 jobs:
   Build:
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/build.yml@v3.1
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/build.yml@v3.2
     with:
       project-to-build: "src/Generator/Generator.csproj"
       project-to-test: "Generator.sln"
       coverage-threshold: 89
 
   Pack:
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/pack.yml@v3.1
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/pack.yml@v3.2
     with:
       project-to-pack: "src/Generator/Generator.csproj"
 
   Scan:
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/scan.yml@v3.1
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/scan.yml@v3.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,16 @@ permissions:
 
 jobs:
   Pack:
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/pack.yml@v3.1.2-test2
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/pack.yml@v3.1.2-test3
     with:
       project-to-pack: "src/Generator/Generator.csproj"
 
   Sign:
     needs: Pack
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/sign.yml@v3.1.2-test2
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/sign.yml@v3.1.2-test3
     secrets: inherit
 
   Publish:
     needs: [Pack, Sign]
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/publish.yml@v3.1.2-test2
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/publish.yml@v3.1.2-test3
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,16 @@ permissions:
 
 jobs:
   Pack:
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/pack.yml@v3.1.2-test
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/pack.yml@v3.1.2-test1
     with:
       project-to-pack: "src/Generator/Generator.csproj"
 
   Sign:
     needs: Pack
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/sign.yml@v3.1.2-test
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/sign.yml@v3.1.2-test1
     secrets: inherit
 
   Publish:
     needs: [Pack, Sign]
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/publish.yml@v3.1.2-test
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/publish.yml@v3.1.2-test1
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,16 @@ permissions:
 
 jobs:
   Pack:
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/pack.yml@v3.1
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/pack.yml@v3.1.2-test
     with:
       project-to-pack: "src/Generator/Generator.csproj"
 
   Sign:
     needs: Pack
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/sign.yml@v3.1
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/sign.yml@v3.1.2-test
     secrets: inherit
 
   Publish:
     needs: [Pack, Sign]
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/publish.yml@v3.1
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/publish.yml@v3.1.2-test
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,16 @@ permissions:
 
 jobs:
   Pack:
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/pack.yml@v3.1.2-test1
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/pack.yml@v3.1.2-test2
     with:
       project-to-pack: "src/Generator/Generator.csproj"
 
   Sign:
     needs: Pack
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/sign.yml@v3.1.2-test1
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/sign.yml@v3.1.2-test2
     secrets: inherit
 
   Publish:
     needs: [Pack, Sign]
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/publish.yml@v3.1.2-test1
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/publish.yml@v3.1.2-test2
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,16 @@ permissions:
 
 jobs:
   Pack:
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/pack.yml@v3.1.2-test4
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/pack.yml@v3.2
     with:
       project-to-pack: "src/Generator/Generator.csproj"
 
   Sign:
     needs: Pack
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/sign.yml@v3.1.2-test4
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/sign.yml@v3.2
     secrets: inherit
 
   Publish:
     needs: [Pack, Sign]
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/publish.yml@v3.1.2-test4
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/publish.yml@v3.2
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,16 @@ permissions:
 
 jobs:
   Pack:
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/pack.yml@v3.1.2-test3
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/pack.yml@v3.1.2-test4
     with:
       project-to-pack: "src/Generator/Generator.csproj"
 
   Sign:
     needs: Pack
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/sign.yml@v3.1.2-test3
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/sign.yml@v3.1.2-test4
     secrets: inherit
 
   Publish:
     needs: [Pack, Sign]
-    uses: microsoft/digitalworkplace-workflows/.github/workflows/publish.yml@v3.1.2-test3
+    uses: microsoft/digitalworkplace-workflows/.github/workflows/publish.yml@v3.1.2-test4
     secrets: inherit


### PR DESCRIPTION
Update Build and Release workflows to [v3.2](https://github.com/microsoft/digitalworkplace-workflows/releases/tag/v3.2)
This is done to resolve the issue in release workflow where sign and publish tasks were failing. The latest version of workflow consists the fixes required.