### PR TITLE
Fix Model Conversion

### DIFF
--- a/src/Generator/Entity/EnumPropEntity.cs
+++ b/src/Generator/Entity/EnumPropEntity.cs
@@ -47,8 +47,12 @@ internal class EnumPropEntity : EnumEntity
         var enumMember = $"EnumMember(Value = \"{enumValueInfo.EnumValue}\")";
         var hasEnDescription = enumValueInfo.Description.ContainsKey(en) && !string.IsNullOrEmpty(enumValueInfo.Description[en]);
         var enDescription = hasEnDescription ? $", Description = \"{enumValueInfo.Description[en]}\"" : string.Empty;
-        var display = $"Display(Name = \"{enumValueInfo.DisplayName[en]}\"{enDescription})";
-        var sourceValue = string.IsNullOrEmpty(enumValueInfo.Comment) ? string.Empty : $"SourceValue(Value = \"{enumValueInfo.Comment}\")";
+        var hasDisplayName = enumValueInfo.DisplayName.ContainsKey(en) && !string.IsNullOrEmpty(enumValueInfo.DisplayName[en]);
+        var displayName = hasDisplayName ? enumValueInfo.DisplayName[en] : enumValueInfo.Name;
+        var display = $"Display(Name = \"{displayName}\"{enDescription})";
+        var hasSourceValue = enumValueInfo.Comment ?? enumValueInfo.EnumValue;
+        var sourceValue = string.IsNullOrEmpty(hasSourceValue.ToString()) ? string.Empty : $"SourceValue(Value = \"{hasSourceValue}\")";
+
         if (!string.IsNullOrEmpty(sourceValue))
         {
             streamWriter.WriteLine($"{indent}{indent}[{string.Join(", ", enumMember, display, sourceValue)}]");

--- a/src/Generator/Entity/ModelEntity.cs
+++ b/src/Generator/Entity/ModelEntity.cs
@@ -13,8 +13,8 @@ internal class ModelEntity : ClassEntity
         Properties = interfaceInfo.Contents.Values
                             .Where(c => c.Id.Labels.Contains(Name) && c.EntityKind == DTEntityKind.Property && c is DTPropertyInfo)
                             .Select(c => (DTPropertyInfo)c);
-        Name = GetClassName(interfaceInfo.Id);
-        Parent = interfaceInfo.Extends.Count() > 0 ? GetClassName(interfaceInfo.Extends.First().Id) : nameof(BasicDigitalTwin);
+        Name = CapitalizeFirstLetter(GetClassName(interfaceInfo.Id));
+        Parent = CapitalizeFirstLetter(interfaceInfo.Extends.Count() > 0 ? GetClassName(interfaceInfo.Extends.First().Id) : nameof(BasicDigitalTwin));
         FileDirectory = ExtractDirectory(ModelId);
         var properties = GetContentInfo<DTPropertyInfo>(interfaceInfo);
         PropertyContent.AddRange(properties.Select(CreateProperty));
@@ -64,6 +64,7 @@ internal class ModelEntity : ClassEntity
 
     private IEnumerable<DTContentInfo> GetContentInfo<T>(DTInterfaceInfo interfaceInfo) where T : DTContentInfo
     {
-        return interfaceInfo.Contents.Select(c => c.Value).Where(c => c.Id.Labels.Contains(Name) && c is T);
+        return interfaceInfo.Contents.Select(c => c.Value)
+            .Where(c => c.Id.Labels.Contains(Name, StringComparer.OrdinalIgnoreCase) && c is T);
     }
 }

--- a/src/Generator/Entity/RelationshipCollectionEntity.cs
+++ b/src/Generator/Entity/RelationshipCollectionEntity.cs
@@ -15,11 +15,11 @@ internal class RelationshipCollectionEntity : ClassEntity
     {
         RelationshipInfo = info;
         Properties = info.Properties;
-        var enclosingClass = info.DefinedIn.Labels.Last();
+        var enclosingClass = CapitalizeFirstLetter(info.DefinedIn.Labels.Last());
         NamePrefix = $"{enclosingClass}{CapitalizeFirstLetter(RelationshipInfo.Name)}";
         Name = $"{NamePrefix}RelationshipCollection";
         FileDirectory = Path.Combine("Relationship", ExtractDirectory(RelationshipInfo.DefinedIn), enclosingClass);
-        var targetType = RelationshipInfo.Target == null ? nameof(BasicDigitalTwin) : $"{RelationshipInfo.Target.Labels.Last()}";
+        var targetType = CapitalizeFirstLetter(RelationshipInfo.Target == null ? nameof(BasicDigitalTwin) : $"{RelationshipInfo.Target.Labels.Last()}");
         Parent = $"RelationshipCollection<{NamePrefix}Relationship, {targetType}>";
         Target = RelationshipInfo.Target == null ? "null" : $"typeof({RelationshipInfo.Target.Labels.Last()})";
     }

--- a/src/Generator/Entity/RelationshipEntity.cs
+++ b/src/Generator/Entity/RelationshipEntity.cs
@@ -17,10 +17,10 @@ internal class RelationshipEntity : ClassEntity
     {
         RelationshipInfo = info;
         Properties = info.Properties;
-        SourceType = info.DefinedIn.Labels.Last();
+        SourceType = CapitalizeFirstLetter(info.DefinedIn.Labels.Last());
         Name = $"{SourceType}{CapitalizeFirstLetter(RelationshipInfo.Name)}Relationship";
         FileDirectory = Path.Combine("Relationship", ExtractDirectory(RelationshipInfo.DefinedIn), SourceType);
-        TargetType = RelationshipInfo.Target == null ? nameof(BasicDigitalTwin) : $"{RelationshipInfo.Target.Labels.Last()}";
+        TargetType = CapitalizeFirstLetter(RelationshipInfo.Target == null ? nameof(BasicDigitalTwin) : $"{RelationshipInfo.Target.Labels.Last()}");
         Parent = $"Relationship<{TargetType}>";
         Target = RelationshipInfo.Target == null ? "null" : $"typeof({RelationshipInfo.Target.Labels.Last()})";
         PropertyContent.AddRange(info.Properties.Select(p => CreateProperty(p, p.Schema)));


### PR DESCRIPTION
- Comments were overwriting EnumValues. I do not think this should be the case. Atleast it is not documented DTDL language specification
- Current generator assumes that every model starts with uppercase letters. This is not always the case. This change ensures that classes/modules are written and then referenced with uppercase letters.